### PR TITLE
Make sure that freeswitch-dos gets created

### DIFF
--- a/install/ubuntu/install_fusionpbx.sh
+++ b/install/ubuntu/install_fusionpbx.sh
@@ -1820,7 +1820,14 @@ failregex = \[WARNING\] sofia_reg.c:\d+ SIP auth failure \(REGISTER\) on sofia p
 ignoreregex =
 DELIM
 
-/bin/cat > /etc/fail2ban/filter.d/freeswitch-dos.conf  <<"DELIM"
+	fi
+	
+		if [ -a /etc/fail2ban/filter.d/freeswitch-dos.conf ]; then
+		/bin/echo "fail2ban filter for freeswitch-dos already done!"
+
+	else
+	
+		/bin/cat > /etc/fail2ban/filter.d/freeswitch-dos.conf  <<"DELIM"
 # Fail2Ban configuration file
 #
 # Author: soapee01


### PR DESCRIPTION
Issue #1029 freeswitch-dos.conf was not getting created even though it needed to be because it was in the if freeswitch.conf stanza and that file always does exist in a fresh install
